### PR TITLE
Correcting td.sample behaviour to match documentation

### DIFF
--- a/R/td.sample.R
+++ b/R/td.sample.R
@@ -15,8 +15,11 @@ td.sample <- function(tdf, sizes = missing, oTable = "", oDatabase = "") {
         if (.td.objectExists(oObj)) 
             stop(gettextf("Table %s already exists.", oObj))
         query <- gettextf("CREATE TABLE %s AS (%s) WITH DATA", oObj, query)
+        df <- try(tdQueryUpdate(query))
+    } else {
+      df <- try(tdQuery(query))
     }
-    df <- try(tdQueryUpdate(query))
+    
     if (is.data.frame(df)) 
         return(df)
     if (length(df) == 1L && df == "No Data") 


### PR DESCRIPTION
Function documentation states that td.sample should return a data.frame when oTable is not given. This pull request implements that behaviour.