### PR TITLE
Install errors

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -11,7 +11,7 @@ td.sample, td.shapiro.wilk, td.sigmoid, td.smirnov, td.solve,
 td.stats, td.t.paired, td.t.unpaired, td.t.unpairedi, td.values,
 td.wilcoxon, td.zscore, tdClose, tdConnect, tdMetadataDB, tdQuery,
 tdSave, td.kmeans, predict.kmeans, ASCII, CEIL, CHR, DECODE, EDITDISTANCE,
-FLOOR, INSTR, INTCAP, LENGTH, LPAD, LTRIM, NGRAM, OREPLACE,OTRANSLATE,
+FLOOR, INSTR, INITCAP, LENGTH, LPAD, LTRIM, NGRAM, OREPLACE,OTRANSLATE,
 RPAD, RTRIM, Ops.td.data.frame, Ops.td.expression, is.td.expression,
 GREATEST, LEAST, td.tapply, subset.td.data.frame, tdQueryUpdate)
 S3method("[", td.data.frame)

--- a/man/LPAD.Rd
+++ b/man/LPAD.Rd
@@ -4,6 +4,7 @@
 \title{
 Wrapper Function LPAD
 }
+\description{
 Makes a wrapper around the fastpath function LPAD
 }
 \usage{
@@ -11,13 +12,13 @@ LPAD(x, ilength, fill_string = " ")
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
-  \item{x}{
+\item{x}{
 a teradata dataframe that contains column(s) of characters that will be padded
 }
-  \item{ilength} {
+\item{ilength}{
 the amount of padding to append to the beginning of the character  
 }
-  \item{fill_string} {
+\item{fill_string}{
 the character used to pad the the column(s) of characters that are passed into the function.  Default character is the empty character
 }
 }

--- a/man/RPAD.Rd
+++ b/man/RPAD.Rd
@@ -15,10 +15,10 @@ RPAD(x, ilength, fill_string = " ")
   \item{x}{
 a teradata dataframe that contains column(s) of characters that will be padded
 }
-  \item{ilength} {
+\item{ilength}{
 the amount of padding to append to the beginning of the character  
 }
-  \item{fill_string} {
+\item{fill_string}{
 the character used to pad the the column(s) of characters that are passed into the function.  Default character is the empty character
 }
 }

--- a/man/on.Rd
+++ b/man/on.Rd
@@ -12,34 +12,34 @@ on(target=NULL, from=NULL, subQuery=NULL, partition=NULL, hash=NULL, order=NULL,
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
-  \item{target}{
+\item{target}{
 a character that represents a name of a table or a query expression
 }
-  \item{from} {
+\item{from}{
 a character that represents a name of the origin of a query expression
 }
-  \item{subQuery}{
+\item{subQuery}{
 a character that represents a nested ON Clause or nested query expression that is part of an ON Clause
 }
-  \item{partition} {
+\item{partition}{
 the parallel option, partition by <column>, or partition by <any>  
 }
- \item{hash} {
+\item{hash}{
 the parallel option, hash by <column>
 }
-  \item{order}{
+\item{order}{
 the parallel option, order by <column> 
 }
-  \item{local_order}{
+\item{local_order}{
 the parallel option, local order by <column>
 }
-  \item{null_order}{
+\item{null_order}{
 specification for the parallel option local_order 
 }
-  \item{dimension} {
+\item{dimension}{
 the parallel option, dimension 
 }
-  \item{as} {
+\item{as}{
 creates and alias    
 }
 }

--- a/man/td.CalcMatrix.Rd
+++ b/man/td.CalcMatrix.Rd
@@ -12,28 +12,28 @@ td.CalcMatrix(selectPhrase=string, ons=string, phase=NULL, calctype=NULL, output
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
-  \item{selectPhrase}{
+\item{selectPhrase}{
  a character that represents the select clause for a query expression
 }
-  \item{ons} {
+\item{ons}{
 a character or list representation of the needed ON Clauses 
 }
-  \item{phase} {
+\item{phase}{
 the character representation of the input of the optional PHASE clause  
 }
-  \item{calctype} {
+\item{calctype}{
 the character representation of the input of the optional CALCTYPE clause  
 }
-  \item{output} {
+\item{output}{
 the character representation of the input of the optional OUTPUT clause  
 }
-  \item{null_handling} {
+\item{null_handling}{
 the character representation of the input of the optional specfication for null handling  
 }
-  \item{optional_operators} {
+\item{optional_operators}{
 the character representation of the other operators that can be specified  
 }
-  \item{as} {
+\item{as}{
 creates and alias  
 }
 }

--- a/man/td.ExecR.Rd
+++ b/man/td.ExecR.Rd
@@ -15,19 +15,19 @@ td.ExecR(selectPhrase=string, ons=list(), returns=NULL, contract=NULL, operator=
   \item{selectPhrase}{
 a character that represents a select phrase
 }
-  \item{ons} {
+  \item{ons}{
 a list or character representation of on clauses 
 }
-  \item{returns} {
+  \item{returns}{
 a file or character representation of a returns clause  
 }
-  \item{contract} {
+  \item{contract}{
 a file or character representation of a contract clause  
 }
-  \item{operator} {
+  \item{operator}{
 a file or character representation of an operator clause 
 }
-  \item{optional_operators} {
+  \item{optional_operators}{
 a character representation of any other needed operators 
 }
 }


### PR DESCRIPTION
`R CMD BUILD .` was throwing the following warnings:

```
$ R CMD BUILD .
* checking for file ‘./DESCRIPTION’ ... OK
* preparing ‘teradataR’:
* checking DESCRIPTION meta-information ... OK
Warning: /private/var/folders/6t/dz_plp0n6qb8wj_zynw173pr0000gn/T/Rtmp4VE56v/Rbuild24b51bf4e99/teradataR/man/LPAD.Rd:8: unexpected '}'
Warning: bad markup (extra space?) at LPAD.Rd:17:17
Warning: bad markup (extra space?) at LPAD.Rd:20:21
Warning: bad markup (extra space?) at RPAD.Rd:18:17
Warning: bad markup (extra space?) at RPAD.Rd:21:21
Warning: bad markup (extra space?) at on.Rd:18:14
Warning: bad markup (extra space?) at on.Rd:24:19
Warning: bad markup (extra space?) at on.Rd:27:13
Warning: bad markup (extra space?) at on.Rd:39:19
Warning: bad markup (extra space?) at on.Rd:42:12
Warning: bad markup (extra space?) at td.CalcMatrix.Rd:18:13
Warning: bad markup (extra space?) at td.CalcMatrix.Rd:21:15
Warning: bad markup (extra space?) at td.CalcMatrix.Rd:24:18
Warning: bad markup (extra space?) at td.CalcMatrix.Rd:27:16
Warning: bad markup (extra space?) at td.CalcMatrix.Rd:30:23
Warning: bad markup (extra space?) at td.CalcMatrix.Rd:33:28
Warning: bad markup (extra space?) at td.CalcMatrix.Rd:36:12
Warning: bad markup (extra space?) at td.ExecR.Rd:18:13
Warning: bad markup (extra space?) at td.ExecR.Rd:21:17
Warning: bad markup (extra space?) at td.ExecR.Rd:24:18
Warning: bad markup (extra space?) at td.ExecR.Rd:27:18
Warning: bad markup (extra space?) at td.ExecR.Rd:30:28
* checking for LF line-endings in source and make files
* checking for empty or unneeded directories
* building ‘teradataR_1.1.0.tar.gz’
```
